### PR TITLE
Fixed a module export error in the graphite lib

### DIFF
--- a/lib/graphite.js
+++ b/lib/graphite.js
@@ -20,7 +20,7 @@ function GraphiteClient(port, host) {
 
 util.inherits(GraphiteClient, events.EventEmitter);
 
-module.exports = GraphiteClient;
+module.exports = {'GraphiteClient': GraphiteClient};
 
 /**
  * Connect to server


### PR DESCRIPTION
main.js expects 'GraphiteClient' key in the object exported from the module.
